### PR TITLE
OPENEUROPA-3135: Use uuid to exclude self when deleting references.

### DIFF
--- a/src/CompositeReferenceFieldManager.php
+++ b/src/CompositeReferenceFieldManager.php
@@ -81,7 +81,7 @@ class CompositeReferenceFieldManager implements CompositeReferenceFieldManagerIn
     $referenced_entities = $entity->get($field_definition->getName())->referencedEntities();
     /** @var \Drupal\Core\Entity\EntityInterface $referenced_entity */
     foreach ($referenced_entities as $referenced_entity) {
-      if ($referenced_entity->id() !== $entity->id() && empty($this->getReferencingEntities($referenced_entity))) {
+      if ($referenced_entity->uuid() !== $entity->uuid() && empty($this->getReferencingEntities($referenced_entity))) {
         $referenced_entity->delete();
       }
     }


### PR DESCRIPTION
## OPENEUROPA-3135

### Description

Use uuid to exclude self when deleting references.
### Change log

- Added:
- Changed: Use uuid to exclude self when deleting references.
- Deprecated:
- Removed:
- Fixed:
- Security:

### Commands

```sh
[Insert commands here]

```

